### PR TITLE
Fix test to match Hello World text

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders hello world greeting', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const greeting = screen.getByText(/hello world/i);
+  expect(greeting).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- fix failing test by checking for Hello World greeting

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877e9d0d9d8832a96546424552a6256